### PR TITLE
feat: 헤더/푸터 레이아웃 기반 구조 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,6 @@ export default defineConfig(
     ignores: [
       'dist',
       'node_modules',
-      '*.config.js',
       '*.config.ts',
       'public',
       'vitest.shims.d.ts',
@@ -171,5 +170,5 @@ export default defineConfig(
       ...jsxA11y.configs.recommended.rules,
     },
   },
-  prettier,
+  prettier
 )

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,14 @@
       "name": "cyber",
       "version": "0.0.0",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "clsx": "^2.1.1",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "tailwind-merge": "^3.5.0"
+        "react-router-dom": "^7.14.1",
+        "tailwind-merge": "^3.5.0",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@commitlint/cli": "^20.5.0",
@@ -625,7 +629,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
       "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -637,7 +640,6 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -648,7 +650,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -868,7 +869,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -879,7 +879,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -890,7 +889,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -900,14 +898,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -918,7 +914,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
       "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -937,7 +932,6 @@
       "version": "0.124.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
       "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -950,7 +944,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -967,7 +960,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -984,7 +976,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1001,7 +992,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1018,7 +1008,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1035,7 +1024,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1052,7 +1040,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1069,7 +1056,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,7 +1072,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1103,7 +1088,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1120,7 +1104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,7 +1120,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1154,7 +1136,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1173,7 +1154,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,7 +1170,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1236,11 +1215,267 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
+      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
+      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
+      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.8.1",
+        "@emnapi/runtime": "^1.8.1",
+        "@emnapi/wasi-threads": "^1.1.0",
+        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
+      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1265,7 +1500,7 @@
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2280,6 +2515,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -2473,7 +2721,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -2533,6 +2780,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
@@ -3103,7 +3363,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -3188,7 +3447,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3428,6 +3686,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -4087,7 +4351,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -4231,7 +4494,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4264,7 +4526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4285,7 +4546,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4306,7 +4566,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4327,7 +4586,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4348,7 +4606,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4369,7 +4626,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4390,7 +4646,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4411,7 +4666,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4432,7 +4686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4453,7 +4706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4474,7 +4726,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4848,6 +5099,24 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4918,7 +5187,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5231,14 +5499,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5261,7 +5527,6 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
       "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5441,6 +5706,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-router": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5567,7 +5870,6 @@
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
       "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.124.0",
@@ -5601,7 +5903,6 @@
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
       "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-array-concat": {
@@ -5674,6 +5975,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5886,7 +6193,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6106,6 +6412,25 @@
         "url": "https://github.com/sponsors/dcastil"
       }
     },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -6120,7 +6445,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6150,7 +6474,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -6306,7 +6629,7 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -6354,7 +6677,6 @@
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -6582,7 +6904,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,14 @@
     ]
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "clsx": "^2.1.1",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "tailwind-merge": "^3.5.0"
+    "react-router-dom": "^7.14.1",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.5.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import "./App.css";
+import { router } from '@app/router'
+import { RouterProvider } from 'react-router-dom'
 
 function App() {
-  return <></>;
+  return <RouterProvider router={router} />
 }
 
-export default App;
+export default App

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,0 +1,1 @@
+export { router } from './router'

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,0 +1,21 @@
+import { MainLayout } from '@components'
+import { ROUTES_PATHS } from '@constants'
+import { HomePage, NotFoundPage } from '@pages'
+import { createBrowserRouter } from 'react-router-dom'
+
+export const router = createBrowserRouter([
+  {
+    path: ROUTES_PATHS.Home,
+    element: <MainLayout />,
+    children: [
+      {
+        index: true,
+        element: <HomePage />,
+      },
+      {
+        path: ROUTES_PATHS.NotFound,
+        element: <NotFoundPage />,
+      },
+    ],
+  },
+])

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './layout'

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet, ScrollRestoration } from 'react-router-dom'
+
+import { SiteFooter } from './SiteFooter'
+import { SiteHeader } from './SiteHeader'
+
+export function MainLayout() {
+  return (
+    <div className="flex min-h-screen flex-col">
+      <SiteHeader />
+      <main className="shell flex-1 py-10 sm:py-12 lg:py-16">
+        <Outlet />
+      </main>
+      <SiteFooter />
+      <ScrollRestoration />
+    </div>
+  )
+}

--- a/src/components/layout/SiteFooter.tsx
+++ b/src/components/layout/SiteFooter.tsx
@@ -1,0 +1,58 @@
+import { FOOTER_LINK_GROUPS, ROUTES_PATHS, SOCIAL_LINKS } from '@constants'
+import { Link } from 'react-router-dom'
+
+export function SiteFooter() {
+  return (
+    <footer className="bg-brand-black text-brand-white">
+      <div className="shell pb-14 sm:pb-16 lg:pb-20">
+        <div className="h-px w-full bg-brand-white/20" />
+
+        <div className="grid gap-12 pt-12 lg:grid-cols-[1.2fr_0.8fr_0.8fr]">
+          <div className="max-w-sm">
+            <Link
+              className="text-lg font-semibold tracking-[-0.08em] transition-opacity hover:opacity-70"
+              to={ROUTES_PATHS.Home}
+            >
+              cyber
+            </Link>
+
+            <p className="mt-6 text-sm leading-7 text-brand-white/65">
+              We are a residential interior design firm located in Portland. Our
+              boutique studio offers more than styling. It shapes calm,
+              considered rooms for everyday rituals.
+            </p>
+
+            <div className="mt-10 flex items-center gap-4">
+              {SOCIAL_LINKS.map(({ href, icon: Icon, label }) => (
+                <a
+                  key={label}
+                  aria-label={label}
+                  className="flex size-9 items-center justify-center rounded-full border border-brand-white/15 text-brand-white/80 transition-colors hover:border-brand-white hover:text-brand-white"
+                  href={href}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  <Icon className="size-4" strokeWidth={1.8} />
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {FOOTER_LINK_GROUPS.map((group) => (
+            <div key={group.title}>
+              <h2 className="text-sm font-medium text-brand-white">
+                {group.title}
+              </h2>
+
+              <ul className="mt-5 space-y-3 text-sm text-brand-white/65">
+                {group.links.map((link) => (
+                  <li key={link.label}>{link.label}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/layout/SiteHeader.tsx
+++ b/src/components/layout/SiteHeader.tsx
@@ -1,0 +1,51 @@
+import { ROUTES_PATHS, UTILITY_LINKS } from '@constants'
+import { cn } from '@util'
+import { Search } from 'lucide-react'
+import { Link, NavLink } from 'react-router-dom'
+
+export function SiteHeader() {
+  return (
+    <header className="border-b border-brand-line/80 bg-brand-white shadow-header">
+      <div className="shell">
+        <div className="flex flex-wrap items-center gap-4 py-5 md:flex-nowrap md:justify-between">
+          <Link
+            className="text-lg font-semibold tracking-[-0.08em] transition-opacity hover:opacity-70"
+            to={ROUTES_PATHS.Home}
+          >
+            cyber
+          </Link>
+
+          <label className="order-3 flex w-full items-center gap-3 rounded-field border border-brand-line bg-brand-surface px-4 py-3 text-sm text-brand-subtle md:order-0 md:max-w-md">
+            <Search className="size-4" strokeWidth={1.7} />
+            <input
+              className="w-full bg-transparent text-sm text-brand-black outline-none placeholder:text-brand-subtle"
+              placeholder="Search"
+              type="search"
+            />
+          </label>
+
+          <nav
+            aria-label="Utility navigation"
+            className="ml-auto flex items-center gap-2"
+          >
+            {UTILITY_LINKS.map(({ href, icon: Icon, label }) => (
+              <NavLink
+                key={href}
+                className={({ isActive }) =>
+                  cn(
+                    'flex size-10 items-center justify-center rounded-full border border-transparent text-brand-black transition-colors hover:border-brand-line hover:bg-brand-surface',
+                    isActive && 'border-brand-line bg-brand-surface'
+                  )
+                }
+                to={href}
+              >
+                <Icon className="size-4" strokeWidth={1.8} />
+                <span className="sr-only">{label}</span>
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,1 @@
+export { MainLayout } from './MainLayout'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,9 @@
+export { ROUTES_PATHS } from './routePaths'
+export { SOCIAL_LINKS } from './socialLinks'
+export { UTILITY_LINKS } from './utilityLinks'
+export {
+  FOOTER_LINK_GROUPS,
+  ROUTED_PAGES,
+  UTILITY_PAGES,
+} from './siteNavigation'
+export type { PageDefinition } from './siteNavigation'

--- a/src/constants/routePaths.ts
+++ b/src/constants/routePaths.ts
@@ -1,0 +1,22 @@
+export const ROUTES_PATHS = {
+  Home: '/',
+  Wishlist: '/wishlist',
+  Cart: '/cart',
+  NotFound: '*',
+  Services: {
+    BonusProgram: '/services/bonus-program',
+    CreditAndPayment: '/services/credit-and-payment',
+    GiftCards: '/services/gift-cards',
+    NonCashAccount: '/services/non-cash-account',
+    Payment: '/services/payment',
+    ServiceContracts: '/services/service-contracts',
+  },
+  Assistance: {
+    ExchangeAndReturn: '/assistance/exchange-and-return',
+    Faq: '/assistance/faq',
+    FindAnOrder: '/assistance/find-an-order',
+    Guarantee: '/assistance/guarantee',
+    TermsOfDelivery: '/assistance/terms-of-delivery',
+    TermsOfUse: '/assistance/terms-of-use',
+  },
+} as const

--- a/src/constants/siteNavigation.ts
+++ b/src/constants/siteNavigation.ts
@@ -1,0 +1,147 @@
+import { ROUTES_PATHS } from './routePaths'
+
+export type PageDefinition = {
+  description: string
+  eyebrow: string
+  href: string
+  label: string
+  title: string
+}
+
+type FooterLinkGroup = {
+  links: PageDefinition[]
+  title: string
+}
+
+export const UTILITY_PAGES: PageDefinition[] = [
+  {
+    description:
+      'Collect bookmarked pieces, finishes, and room ideas in one calm list.',
+    eyebrow: 'Saved pieces',
+    href: ROUTES_PATHS.Wishlist,
+    label: 'Wishlist',
+    title: 'Your wishlist',
+  },
+  {
+    description:
+      'Review selected objects and shape a cleaner, more focused checkout flow.',
+    eyebrow: 'Ready to order',
+    href: ROUTES_PATHS.Cart,
+    label: 'Cart',
+    title: 'Your cart',
+  },
+]
+
+export const FOOTER_LINK_GROUPS: FooterLinkGroup[] = [
+  {
+    title: 'Services',
+    links: [
+      {
+        description:
+          'A loyalty layer for returning clients who build rooms over time.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.BonusProgram,
+        label: 'Bonus program',
+        title: 'Bonus program',
+      },
+      {
+        description:
+          'Flexible gifting options for clients who want to share the studio.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.GiftCards,
+        label: 'Gift cards',
+        title: 'Gift cards',
+      },
+      {
+        description:
+          'Clear payment guidance for custom orders, deposits, and timelines.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.CreditAndPayment,
+        label: 'Credit and payment',
+        title: 'Credit and payment',
+      },
+      {
+        description:
+          'Service agreements that define scope, delivery windows, and support.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.ServiceContracts,
+        label: 'Service contracts',
+        title: 'Service contracts',
+      },
+      {
+        description:
+          'Business billing support for clients who work through company accounts.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.NonCashAccount,
+        label: 'Non-cash account',
+        title: 'Non-cash account',
+      },
+      {
+        description:
+          'Payment options designed to stay transparent from quote to final order.',
+        eyebrow: 'Services',
+        href: ROUTES_PATHS.Services.Payment,
+        label: 'Payment',
+        title: 'Payment',
+      },
+    ],
+  },
+  {
+    title: 'Assistance to the buyer',
+    links: [
+      {
+        description:
+          'Track project progress, delivery timing, and current order status.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.FindAnOrder,
+        label: 'Find an order',
+        title: 'Find an order',
+      },
+      {
+        description:
+          'A summary of shipping timelines, methods, and regional expectations.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.TermsOfDelivery,
+        label: 'Terms of delivery',
+        title: 'Terms of delivery',
+      },
+      {
+        description:
+          'Return and exchange guidance for made-to-order and stocked pieces.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.ExchangeAndReturn,
+        label: 'Exchange and return of goods',
+        title: 'Exchange and return of goods',
+      },
+      {
+        description:
+          'Warranty details for craftsmanship, material integrity, and support.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.Guarantee,
+        label: 'Guarantee',
+        title: 'Guarantee',
+      },
+      {
+        description:
+          'Answers to the recurring questions that come up during purchase.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.Faq,
+        label: 'Frequently asked questions',
+        title: 'Frequently asked questions',
+      },
+      {
+        description:
+          'Site usage terms covering content, ordering, and privacy boundaries.',
+        eyebrow: 'Assistance to the buyer',
+        href: ROUTES_PATHS.Assistance.TermsOfUse,
+        label: 'Terms of use of the site',
+        title: 'Terms of use of the site',
+      },
+    ],
+  },
+]
+
+export const ROUTED_PAGES = [
+  ...UTILITY_PAGES,
+  ...FOOTER_LINK_GROUPS.flatMap((group) => group.links),
+]

--- a/src/constants/socialLinks.ts
+++ b/src/constants/socialLinks.ts
@@ -1,0 +1,24 @@
+import { Bird, Camera, MessagesSquare, Music2 } from 'lucide-react'
+
+export const SOCIAL_LINKS = [
+  {
+    href: 'https://twitter.com',
+    icon: Bird,
+    label: 'Twitter',
+  },
+  {
+    href: 'https://facebook.com',
+    icon: MessagesSquare,
+    label: 'Facebook',
+  },
+  {
+    href: 'https://www.tiktok.com',
+    icon: Music2,
+    label: 'TikTok',
+  },
+  {
+    href: 'https://instagram.com',
+    icon: Camera,
+    label: 'Instagram',
+  },
+]

--- a/src/constants/utilityLinks.ts
+++ b/src/constants/utilityLinks.ts
@@ -1,0 +1,16 @@
+import { Heart, ShoppingCart } from 'lucide-react'
+
+import { ROUTES_PATHS } from './routePaths'
+
+export const UTILITY_LINKS = [
+  {
+    href: ROUTES_PATHS.Wishlist,
+    icon: Heart,
+    label: 'Wishlist',
+  },
+  {
+    href: ROUTES_PATHS.Cart,
+    icon: ShoppingCart,
+    label: 'Cart',
+  },
+]

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,67 @@
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap');
+@import 'tailwindcss';
+
+@theme {
+  --color-brand-white: #ffffff;
+  --color-brand-black: #000000;
+  --color-brand-line: #cfcfcf;
+  --color-brand-surface: #f5f5f5;
+  --color-brand-copy: #656565;
+  --color-brand-subtle: #989898;
+  --font-sans: 'Manrope', 'Noto Sans KR', sans-serif;
+  --shadow-card: 0 24px 80px rgba(0, 0, 0, 0.08);
+  --shadow-header: 0 12px 40px rgba(0, 0, 0, 0.06);
+  --radius-field: 999px;
+  --radius-shell: 2rem;
+}
+
+@layer base {
+  * {
+    box-sizing: border-box;
+  }
+
+  html {
+    background-color: var(--color-brand-surface);
+  }
+
+  body {
+    margin: 0;
+    min-height: 100vh;
+    background:
+      radial-gradient(circle at top center, rgba(255, 255, 255, 0.9), transparent 28rem),
+      linear-gradient(180deg, #ffffff 0%, #f5f5f5 100%);
+    color: var(--color-brand-black);
+    font-family: var(--font-sans);
+    text-rendering: optimizeLegibility;
+  }
+
+  #root {
+    min-height: 100vh;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  button,
+  input {
+    font: inherit;
+  }
+
+  button {
+    cursor: pointer;
+  }
+
+  ::selection {
+    background-color: var(--color-brand-black);
+    color: var(--color-brand-white);
+  }
+}
+
+@layer components {
+  .shell {
+    width: min(calc(100% - 2rem), 90rem);
+    margin-inline: auto;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App.tsx";
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 
-createRoot(document.getElementById("root")!).render(
+import App from './App.tsx'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
-);
+  </StrictMode>
+)

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,0 +1,3 @@
+export function HomePage() {
+  return null
+}

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,23 @@
+import { ROUTES_PATHS } from '@constants'
+import { ArrowRight } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+export function NotFoundPage() {
+  return (
+    <section className="rounded-shell border border-brand-line bg-brand-white p-8 shadow-card sm:p-10">
+      <p className="text-4xl tracking-[0.32em] text-brand-subtle">404</p>
+
+      <h1 className="mt-4 text-4xl font-semibold tracking-[-0.05em] text-brand-black sm:text-5xl">
+        경로가 존재하지 않습니다.
+      </h1>
+
+      <Link
+        className="mt-10 inline-flex items-center gap-2 rounded-full bg-brand-black px-5 py-3 text-sm font-medium text-brand-white transition-opacity hover:opacity-85"
+        to={ROUTES_PATHS.Home}
+      >
+        Back home
+        <ArrowRight className="size-4" strokeWidth={1.8} />
+      </Link>
+    </section>
+  )
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,2 @@
+export { HomePage } from './HomePage'
+export { NotFoundPage } from './NotFoundPage'

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export { cn } from './cn'

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -6,6 +6,24 @@
     "module": "esnext",
     "types": ["vite/client"],
     "skipLibCheck": true,
+    "ignoreDeprecations": "6.0",
+    "baseUrl": ".",
+    "paths": {
+      "@app": ["src/app/index.ts"],
+      "@app/*": ["src/app/*"],
+      "@assets/*": ["src/assets/*"],
+      "@components": ["src/components/index.ts"],
+      "@components/*": ["src/components/*"],
+      "@constants": ["src/constants/index.ts"],
+      "@constants/*": ["src/constants/*"],
+      "@feature/*": ["src/feature/*"],
+      "@pages": ["src/pages/index.ts"],
+      "@pages/*": ["src/pages/*"],
+      "@stores/*": ["src/stores/*"],
+      "@types/*": ["src/types/*"],
+      "@util": ["src/util/index.ts"],
+      "@util/*": ["src/util/*"]
+    },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,24 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@app': path.resolve(__dirname, './src/app'),
+      '@assets': path.resolve(__dirname, './src/assets'),
+      '@components': path.resolve(__dirname, './src/components'),
+      '@constants': path.resolve(__dirname, './src/constants'),
+      '@feature': path.resolve(__dirname, './src/feature'),
+      '@features': path.resolve(__dirname, './src/feature'),
+      '@pages': path.resolve(__dirname, './src/pages'),
+      '@stores': path.resolve(__dirname, './src/stores'),
+      '@types': path.resolve(__dirname, './src/types'),
+      '@util': path.resolve(__dirname, './src/util'),
+      '@utils': path.resolve(__dirname, './src/util'),
+    },
+  },
 })


### PR DESCRIPTION
## 📌 작업 내용

헤더/푸터 레이아웃 기반 구조 추가
- react-router-dom 기반 앱 라우터 및 메인 레이아웃 추가
- Tailwind 토큰과 전역 스타일 초기 설정 추가
- Vite alias 및 TypeScript paths 설정 추가
- Tailwind, Lucide, Router 관련 의존성 추가

헤더/푸터 컴포넌트와 라우트 상수 추가
- SiteHeader 및 SiteFooter 레이아웃 컴포넌트 추가
- routePaths, utilityLinks, socialLinks 상수 파일 추가

 페이지 라우팅 상수와 기본 페이지 구조 추가
- footer/utility 네비게이션 상수 정의 추가
- HomePage와 NotFoundPage 기본 페이지 추가
- pages, util 배럴 export 추가

## 🔗 관련 이슈

- closes #7 

## ✅ 체크리스트

- [ ] 코드 컨벤션 확인
- [ ] lint 에러 없음
- [ ] 빌드 정상 확인
